### PR TITLE
Remove moduleId from Component snippet

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -97,7 +97,6 @@
       "import { Component, OnInit } from '@angular/core';",
       "",
       "@Component({",
-      "\tmoduleId: module.id,",
       "\tselector: '${selector}',",
       "\ttemplateUrl: '${fileName}.component.html'",
       "})",


### PR DESCRIPTION
Remove moduleId from Component snippet as specifying moduleId is no longer recommended.

See https://angular.io/guide/change-log#all-mention-of-moduleid-removed-component-relative-paths-guide-deleted-2017-03-13